### PR TITLE
fix: 테이프 가득 찼을 때 뒤로가기 버튼 접근 에러

### DIFF
--- a/src/components/audio/index.tsx
+++ b/src/components/audio/index.tsx
@@ -74,19 +74,12 @@ const AudioPlayer = forwardRef<HTMLDivElement, AudioPlayerProps>(
     }, [audioPlayer]);
 
     useEffect(() => {
-      if (!tempPause && currentTime !== 0 && currentTime !== duration) {
-        setIsPlaying(true);
-        setIsPlayAudio(true);
-      }
-    }, [currentTime, duration, setIsPlayAudio, tempPause]);
-
-    useEffect(() => {
-      (currentTime === 0 || duration === currentTime) && setIsPlaying(false);
-    }, [currentTime, duration]);
-
-    useEffect(() => {
-      isPlaying && !tempPause ? setIsPlayAudio(true) : setIsPlayAudio(false);
+      setIsPlayAudio(isPlaying && !tempPause);
     }, [isPlaying, setIsPlayAudio, tempPause]);
+
+    useEffect(() => {
+      setIsPlaying(currentTime !== 0 && currentTime !== duration && !tempPause);
+    }, [currentTime, duration, tempPause]);
 
     useEffect(() => {
       const link = audioLink;

--- a/src/components/audio/index.tsx
+++ b/src/components/audio/index.tsx
@@ -74,31 +74,11 @@ const AudioPlayer = forwardRef<HTMLDivElement, AudioPlayerProps>(
     }, [audioPlayer]);
 
     useEffect(() => {
-      const progressCircle = progressBar.current;
-      const handlePresse = () => {
-        setIsPlaying(false);
-        setIsPlayAudio(false);
-        setTempPause(true);
-      };
-      if (tempPause) {
-        progressCircle?.addEventListener('mousedown', handlePresse);
-        progressCircle?.addEventListener('mouseup', handlePresse);
-
-        progressCircle?.addEventListener('touchstart', handlePresse);
-        progressCircle?.addEventListener('touchend', handlePresse);
-        progressCircle?.addEventListener('touchmove', handlePresse);
-        progressCircle?.addEventListener('touchcancel', handlePresse);
+      if (!tempPause && currentTime !== 0 && currentTime !== duration) {
+        setIsPlaying(true);
+        setIsPlayAudio(true);
       }
-      return () => {
-        progressCircle?.removeEventListener('mousedown', handlePresse);
-        progressCircle?.removeEventListener('mouseup', handlePresse);
-
-        progressCircle?.removeEventListener('touchstart', handlePresse);
-        progressCircle?.removeEventListener('touchend', handlePresse);
-        progressCircle?.removeEventListener('touchmove', handlePresse);
-        progressCircle?.removeEventListener('touchcancel', handlePresse);
-      };
-    }, [tempPause, setIsPlayAudio]);
+    }, [currentTime, duration, setIsPlayAudio, tempPause]);
 
     useEffect(() => {
       (currentTime === 0 || duration === currentTime) && setIsPlaying(false);

--- a/src/pages/create-tape-completed.tsx
+++ b/src/pages/create-tape-completed.tsx
@@ -215,7 +215,11 @@ const CreateTapeCompleted = () => {
         onhandleBackward={MoveBackward}
         onhandleForward={MoveForward}
         preventMovingForward={currentIndex === 0}
-        preventMovingBack={currentIndex >= tracks.length - 1}
+        preventMovingBack={
+          ((!fullTapeLink && currentIndex === tracks.length - 1) as boolean) ||
+          ((fullTapeLink &&
+            currentTapeId === (tapeId as number) * MAX_NUMBER) as boolean)
+        }
       />
       <TapeCount>
         <span> Total {tracks.length}/12</span>


### PR DESCRIPTION
## What is this PR do?
- [ ] New Features 
- [x] Fixed a bug
- [ ] Refectoring
- [ ] Style
- [ ] Code Formatting

## Change
- [x] 버튼 비활성화 에러 수정 (전체 테이프에 접근 가능하도록)
- [x] audio 컴포넌트에서 progressbar, 재생 상황, 버튼 아이콘 상태 공유 원활하도록 수정
- [x] 재생, 일시정지 상태 관리하는 코드 리펙토링  
